### PR TITLE
The message log level will now be displayed, instead of the limit log level

### DIFF
--- a/QLogger.cpp
+++ b/QLogger.cpp
@@ -63,7 +63,7 @@ namespace QLogger
         const auto logWriter = manager->getLogWriter(module);
 
         if (logWriter and logWriter->getLevel() <= level)
-                logWriter->write(module,message);
+                logWriter->write(module,message, level);
     }
 
     //QLoggerManager
@@ -167,7 +167,7 @@ namespace QLogger
         return renamed ? newName : "";
     }
 
-    void QLoggerWriter::write(const QString &module, const QString &message)
+    void QLoggerWriter::write(const QString &module, const QString &message, const LogLevel &messageLogLevel)
     {
         QFile file(mFileDestination);
 
@@ -181,7 +181,7 @@ namespace QLogger
             if (!newName.isEmpty())
                 out << QString("%1 - Previous log %2\n").arg(dtFormat).arg(newName);
 
-            const auto logLevel = QLoggerManager::levelToText(m_level);
+            const auto logLevel = QLoggerManager::levelToText(messageLogLevel);
             const auto text = QString("[%1] [%2] {%3} %4\n").arg(dtFormat).arg(logLevel).arg(module).arg(message);
 
             out << text;

--- a/QLogger.h
+++ b/QLogger.h
@@ -120,8 +120,9 @@ namespace QLogger
              *
              * @param module The module that corresponds to the message.
              * @param message The message log.
+             * @param messageLogLevel The log level of the message
              */
-            void write(const QString &module, const QString &message);
+            void write(const QString &module, const QString &message, const LogLevel &messageLogLevel);
 
         private:
             /**


### PR DESCRIPTION
I'm using your code in a project, it is really useful, but I feel like the displayed log level shouldn't be the limit. It doesn't make any sense. All the lines will be marked as "trace", while some are errors. So, just a small pull request to fix that.