### PR TITLE
New features and logging options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.user
 
+QLoggerTest/QLoggerTest-d_5_13_1_MinGW_32bit/

--- a/QLogger.cpp
+++ b/QLogger.cpp
@@ -1,18 +1,22 @@
-#include <QLogger.h>
+#include "QLogger.h"
 
 #include "QLoggerWriter.h"
 
-#include <QDir>
 #include <QDateTime>
+#include <QDir>
 
 Q_DECLARE_METATYPE(QLogger::LogLevel);
+Q_DECLARE_METATYPE(QLogger::LogMode);
+Q_DECLARE_METATYPE(QLogger::LogFileDisplay);
+Q_DECLARE_METATYPE(QLogger::LogMessageDisplay);
 
 namespace QLogger
 {
 
-void QLog_(const QString &module, LogLevel level, const QString &message, const QString &file, int line)
+void QLog_(const QString &module, LogLevel level, const QString &message,
+           const QString &function, const QString &file, int line)
 {
-   QLoggerManager::getInstance()->enqueueMessage(module, level, message, file, line);
+   QLoggerManager::getInstance()->enqueueMessage(module, level, message, function, file, line);
 }
 
 static const int QUEUE_LIMIT = 100;
@@ -20,8 +24,7 @@ static const int QUEUE_LIMIT = 100;
 QLoggerManager::QLoggerManager()
    : mMutex(QMutex::Recursive)
 {
-   QDir dir(QDir::currentPath());
-   dir.mkdir("logs");
+
 }
 
 QLoggerManager *QLoggerManager::getInstance()
@@ -31,22 +34,31 @@ QLoggerManager *QLoggerManager::getInstance()
    return &INSTANCE;
 }
 
-bool QLoggerManager::addDestination(const QString &fileDest, const QString &module, LogLevel level)
+bool QLoggerManager::addDestination(const QString &fileDest, const QString &module, LogLevel level,
+                                    const QString &fileFolderDestination, LogMode mode,
+                                    LogFileDisplay fileSuffixIfFull, LogMessageDisplays messageOptions, bool notify)
 {
    QMutexLocker lock(&mMutex);
 
    if (!mModuleDest.contains(module))
    {
-      const auto log = new QLoggerWriter(fileDest, level);
+       const auto log = new QLoggerWriter((fileDest.isEmpty() ? mDefaultFileDestination : fileDest),
+                                          (level == LogLevel::Warning ? mDefaultLevel : level),
+                                          (fileFolderDestination.isEmpty() ? mDefaultFileDestinationFolder : QDir::fromNativeSeparators(fileFolderDestination)),
+                                          (mode == LogMode::OnlyFile ? mDefaultMode : mode),
+                                          (fileSuffixIfFull == LogFileDisplay::DateTime ? mDefaultFileSuffixIfFull : fileSuffixIfFull),
+                                          (messageOptions.testFlag(LogMessageDisplay::Default) ? mDefaultMessageOptions : messageOptions));
+      log->setMaxFileSize(mDefaultMaxFileSize);
       log->stop(mIsStop);
 
-      const auto threadId = QString("%1").arg((quintptr)QThread::currentThread(), QT_POINTER_SIZE * 2, 16, QChar('0'));
-
-      log->enqueue(QDateTime::currentDateTime(), threadId, module, LogLevel::Info, "", -1, "Adding destination!");
-
+      if (notify) {
+        const auto threadId = QString("%1").arg((quintptr)QThread::currentThread(), QT_POINTER_SIZE * 2, 16, QChar('0'));
+        log->enqueue(QDateTime::currentDateTime(), threadId, module, LogLevel::Info, "", "", -1, "Adding destination!");
+      }
       mModuleDest.insert(module, log);
 
-      log->start();
+      if (mode != LogMode::Disabled)
+        log->start();
 
       return true;
    }
@@ -54,7 +66,9 @@ bool QLoggerManager::addDestination(const QString &fileDest, const QString &modu
    return false;
 }
 
-bool QLoggerManager::addDestination(const QString &fileDest, const QStringList &modules, LogLevel level)
+bool QLoggerManager::addDestination(const QString &fileDest, const QStringList &modules, LogLevel level,
+                                    const QString &fileFolderDestination, LogMode mode,
+                                    LogFileDisplay fileSuffixIfFull, LogMessageDisplays messageOptions, bool notify)
 {
    QMutexLocker lock(&mMutex);
    bool allAdded = false;
@@ -63,19 +77,26 @@ bool QLoggerManager::addDestination(const QString &fileDest, const QStringList &
    {
       if (!mModuleDest.contains(module))
       {
-         const auto log = new QLoggerWriter(fileDest, level);
+          const auto log = new QLoggerWriter((fileDest.isEmpty() ? mDefaultFileDestination : fileDest),
+                                             (level == LogLevel::Warning ? mDefaultLevel : level),
+                                             (fileFolderDestination.isEmpty() ? mDefaultFileDestinationFolder : QDir::fromNativeSeparators(fileFolderDestination)),
+                                             (mode == LogMode::OnlyFile ? mDefaultMode : mode),
+                                             (fileSuffixIfFull == LogFileDisplay::DateTime ? mDefaultFileSuffixIfFull : fileSuffixIfFull),
+                                             (messageOptions.testFlag(LogMessageDisplay::Default) ? mDefaultMessageOptions : messageOptions));
+         log->setMaxFileSize(mDefaultMaxFileSize);
          log->stop(mIsStop);
 
          mModuleDest.insert(module, log);
 
          if (!mIsStop)
          {
-            const auto threadId
-                = QString("%1").arg((quintptr)QThread::currentThread(), QT_POINTER_SIZE * 2, 16, QChar('0'));
-
-            log->enqueue(QDateTime::currentDateTime(), threadId, module, LogLevel::Info, "", -1, "Adding destination!");
-
-            log->start();
+            if (notify) {
+                const auto threadId
+                        = QString("%1").arg((quintptr)QThread::currentThread(), QT_POINTER_SIZE * 2, 16, QChar('0'));
+                log->enqueue(QDateTime::currentDateTime(), threadId, module, LogLevel::Info, "", "", -1, "Adding destination!");
+            }
+            if (mode != LogMode::Disabled)
+              log->start();
          }
 
          allAdded = true;
@@ -107,15 +128,21 @@ void QLoggerManager::clearFileDestinationFolder(const QString &fileFolderDestina
     }
 }
 
+void QLoggerManager::setDefaultFileDestinationFolder(const QString &fileDestinationFolder)
+{
+    mDefaultFileDestinationFolder = QDir::fromNativeSeparators(fileDestinationFolder);
+}
+
 void QLoggerManager::writeAndDequeueMessages(const QString &module)
 {
    QMutexLocker lock(&mMutex);
 
-   const auto logWriter = mModuleDest.value(module);
+   const auto logWriter = mModuleDest.value(module, Q_NULLPTR);
 
    if (logWriter && !logWriter->isStop())
    {
-      for (const auto &values : qAsConst(mNonWriterQueue))
+      const QList<QVector<QVariant>> values = mNonWriterQueue.values(module);
+      for (const auto &values : values)
       {
          const auto level = qvariant_cast<LogLevel>(values.at(2).toInt());
 
@@ -123,11 +150,12 @@ void QLoggerManager::writeAndDequeueMessages(const QString &module)
          {
             const auto datetime = values.at(0).toDateTime();
             const auto threadId = values.at(1).toString();
-            const auto file = values.at(3).toString();
-            const auto line = values.at(4).toInt();
-            const auto message = values.at(5).toString();
+            const auto function = values.at(3).toString();
+            const auto file = values.at(4).toString();
+            const auto line = values.at(5).toInt();
+            const auto message = values.at(6).toString();
 
-            logWriter->enqueue(datetime, threadId, module, level, file, line, message);
+            logWriter->enqueue(datetime, threadId, module, level, function, file, line, message);
          }
       }
 
@@ -135,24 +163,24 @@ void QLoggerManager::writeAndDequeueMessages(const QString &module)
    }
 }
 
-void QLoggerManager::enqueueMessage(const QString &module, LogLevel level, const QString &message, QString file,
-                                    int line)
+void QLoggerManager::enqueueMessage(const QString &module, LogLevel level, const QString &message, const QString& function,
+                                    const QString& file, int line)
 {
    QMutexLocker lock(&mMutex);
    const auto threadId = QString("%1").arg((quintptr)QThread::currentThread(), QT_POINTER_SIZE * 2, 16, QChar('0'));
    const auto fileName = file.mid(file.lastIndexOf('/') + 1);
-   const auto logWriter = mModuleDest.value(module);
+   const auto logWriter = mModuleDest.value(module, Q_NULLPTR);
 
-   if (logWriter && !logWriter->isStop() && logWriter->getLevel() <= level)
+   if (logWriter && logWriter->getMode() != LogMode::Disabled && !logWriter->isStop() && logWriter->getLevel() <= level)
    {
       writeAndDequeueMessages(module);
 
-      logWriter->enqueue(QDateTime::currentDateTime(), threadId, module, level, fileName, line, message);
+      logWriter->enqueue(QDateTime::currentDateTime(), threadId, module, level, function, fileName, line, message);
    }
    else if (!logWriter && mNonWriterQueue.count(module) < QUEUE_LIMIT)
       mNonWriterQueue.insert(
           module,
-          { QDateTime::currentDateTime(), threadId, QVariant::fromValue<LogLevel>(level), fileName, line, message });
+          { QDateTime::currentDateTime(), threadId, QVariant::fromValue<LogLevel>(level), function, fileName, line, message });
 }
 
 void QLoggerManager::pause()
@@ -172,15 +200,37 @@ void QLoggerManager::resume()
    mIsStop = false;
 
    for (auto &logWriter : mModuleDest)
-      logWriter->stop(mIsStop);
+       logWriter->stop(mIsStop);
+}
+
+void QLoggerManager::overwriteLogMode(LogMode mode)
+{
+    QMutexLocker lock(&mMutex);
+
+    this->setDefaultMode(mode);
+
+    for (auto &logWriter : mModuleDest)
+        logWriter->setLogMode(mode);
 }
 
 void QLoggerManager::overwriteLogLevel(LogLevel level)
 {
    QMutexLocker lock(&mMutex);
 
+   this->setDefaultLevel(level);
+
    for (auto &logWriter : mModuleDest)
-      logWriter->setLogLevel(level);
+       logWriter->setLogLevel(level);
+}
+
+void QLoggerManager::overwriteMaxFileSize(int maxSize)
+{
+    QMutexLocker lock(&mMutex);
+
+    this->setDefaultMaxFileSize(maxSize);
+
+    for (auto &logWriter : mModuleDest)
+        logWriter->setMaxFileSize(maxSize);
 }
 
 QLoggerManager::~QLoggerManager()

--- a/QLogger.cpp
+++ b/QLogger.cpp
@@ -85,6 +85,28 @@ bool QLoggerManager::addDestination(const QString &fileDest, const QStringList &
    return allAdded;
 }
 
+void QLoggerManager::clearFileDestinationFolder(const QString &fileFolderDestination, int days)
+{
+    QDir dir(fileFolderDestination + QStringLiteral("/logs"));
+    if (!dir.exists()) {
+        return;
+    }
+
+    dir.setFilter(QDir::Files | QDir::Hidden | QDir::NoSymLinks);
+    const QFileInfoList list = dir.entryInfoList();
+
+    const QDateTime now = QDateTime::currentDateTime();
+
+    for (int i = 0; i < list.size(); ++i) {
+        QFileInfo fileInfo = list.at(i);
+
+        if (fileInfo.lastModified().daysTo(now) >= days) {
+            //remove file
+            dir.remove(fileInfo.fileName());
+        }
+    }
+}
+
 void QLoggerManager::writeAndDequeueMessages(const QString &module)
 {
    QMutexLocker lock(&mMutex);

--- a/QLogger.h
+++ b/QLogger.h
@@ -53,9 +53,15 @@ public:
     * @param fileDest The file name and path to print logs.
     * @param module The module that will be stored in the file.
     * @param level The maximum level allowed.
+    * @param fileFolderDestination The complete folder destination.
+    * @param mode The logging mode.
+    * @param fileSuffixIfFull The filename suffix if the file is full.
     * @return Returns true if any error have been done.
     */
-   bool addDestination(const QString &fileDest, const QString &module, LogLevel level);
+   bool addDestination(const QString &fileDest, const QString &module, LogLevel level=LogLevel::Warning,
+                       const QString &fileFolderDestination=QString(), LogMode mode=LogMode::OnlyFile,
+                       LogFileDisplay fileSuffixIfFull=LogFileDisplay::DateTime,
+                       LogMessageDisplays messageOptions=LogMessageDisplay::Default, bool notify=true);
    /**
     * @brief This method creates a QLoogerWriter that stores the name of the file and the log
     * level assigned to it. Here is added to the map the different modules assigned to each
@@ -65,10 +71,15 @@ public:
     * @param fileDest The file name and path to print logs.
     * @param modules The modules that will be stored in the file.
     * @param level The maximum level allowed.
+    * @param fileFolderDestination The complete folder destination.
+    * @param mode The logging mode.
+    * @param fileSuffixIfFull The filename suffix if the file is full.
     * @return Returns true if any error have been done.
     */
-   bool addDestination(const QString &fileDest, const QStringList &modules, LogLevel level);
-   
+   bool addDestination(const QString &fileDest, const QStringList &modules, LogLevel level=LogLevel::Warning,
+                       const QString &fileFolderDestination=QString(),LogMode mode=LogMode::OnlyFile,
+                       LogFileDisplay fileSuffixIfFull=LogFileDisplay::DateTime,
+                       LogMessageDisplays messageOptions=LogMessageDisplay::Default, bool notify=true);
    /**
     * @brief Clears old log files from the current storage folder.
     *
@@ -77,16 +88,21 @@ public:
     *        this value will be removed. If days is -1, deletes any log file.
     */
    static void clearFileDestinationFolder(const QString &fileFolderDestination, int days=-1);
-   
    /**
     * @brief enqueueMessage Enqueues a message in the corresponding QLoggerWritter.
     * @param module The module that writes the message.
     * @param level The level of the message.
     * @param message The message to log.
+    * @param function The function in the file where the log comes from.
     * @param file The file that logs.
     * @param line The line in the file where the log comes from.
     */
-   void enqueueMessage(const QString &module, LogLevel level, const QString &message, QString file, int line);
+   void enqueueMessage(const QString &module, LogLevel level, const QString &message, const QString &function, const QString& file, int line);
+
+   /**
+    * @brief Whether the QLogger is paused or not.
+    */
+   bool isPaused() const { return mIsStop; }
 
    /**
     * @brief pause Pauses all QLoggerWriters.
@@ -99,11 +115,53 @@ public:
    void resume();
 
    /**
-    * @brief overwriteLogLevel Overwrites the log level in all the destinations
+    * @brief getDefaultFileDestinationFolder Gets the defaut file destination folder.
+    * @return The file destination folder
+    */
+   QString getDefaultFileDestinationFolder() const { return mDefaultFileDestinationFolder; }
+
+   /**
+    * @brief getDefaultMode Gets the default log mode.
+    * @return The log mode
+    */
+   LogMode getDefaultMode() const { return mDefaultMode; }
+
+   /**
+    * @brief getDefaultLevel Gets the default log level.
+    * @return The log level
+    */
+   LogLevel getDefaultLevel() const { return mDefaultLevel; }
+
+   /**
+    * @brief Sets default values for QLoggerWritter parameters. Usefull for multiple QLoggerWritter.
+    */
+   void setDefaultFileDestinationFolder(const QString& fileDestinationFolder);
+   void setDefaultFileDestination(const QString& fileDestination) { mDefaultFileDestination = fileDestination; }
+   void setDefaultFileSuffixIfFull(LogFileDisplay fileSuffixIfFull) { mDefaultFileSuffixIfFull = fileSuffixIfFull; }
+
+   void setDefaultLevel(LogLevel level) { mDefaultLevel = level; }
+   void setDefaultMode(LogMode mode) { mDefaultMode = mode; }
+   void setDefaultMaxFileSize(int maxFileSize) { mDefaultMaxFileSize = maxFileSize; }
+   void setDefaultMessageOptions(LogMessageDisplays messageOptions) { mDefaultMessageOptions = messageOptions; }
+
+   /**
+    * @brief overwriteLogMode Overwrites the logging mode in all the destinations. Sets the default logging mode.
+    *
+    * @param mode The new log mode
+    */
+   void overwriteLogMode(LogMode mode);
+   /**
+    * @brief overwriteLogLevel Overwrites the log level in all the destinations. Sets the default log level.
     *
     * @param level The new log level
     */
    void overwriteLogLevel(LogLevel level);
+   /**
+    * @brief overwriteMaxFileSize Overwrites the maximum file size in all the destinations. Sets the default max file size.
+    *
+    * @param maxSize The new file size
+    */
+   void overwriteMaxFileSize(int maxSize);
 
 private:
    /**
@@ -120,6 +178,18 @@ private:
     * @brief Defines the queue of messages when no writters have been set yet.
     */
    QMultiMap<QString, QVector<QVariant>> mNonWriterQueue;
+
+   /**
+    * @brief Default values for QLoggerWritter parameters. Usefull for multiple QLoggerWritter.
+    */
+   QString mDefaultFileDestinationFolder;
+   QString mDefaultFileDestination;
+   LogFileDisplay mDefaultFileSuffixIfFull = LogFileDisplay::DateTime;
+
+   LogMode mDefaultMode = LogMode::OnlyFile;
+   LogLevel mDefaultLevel = LogLevel::Warning;
+   int mDefaultMaxFileSize = 1024 * 1024;  //! @note 1Mio
+   LogMessageDisplays mDefaultMessageOptions = LogMessageDisplay::Default;
 
    /**
     * @brief Mutex to make the method thread-safe.
@@ -143,7 +213,6 @@ private:
     */
    void writeAndDequeueMessages(const QString &module);
 };
-}
 
 /**
  * @brief Here is done the call to write the message in the module. First of all is confirmed
@@ -153,9 +222,14 @@ private:
  * @param module The module that the message references.
  * @param level The level of the message.
  * @param message The message.
+ * @param function The function in the file where the log comes from.
+ * @param file The file that logs.
+ * @param line The line in the file where the log comes from.
  */
-void QLog_(const QString &module, QLogger::LogLevel level, const QString &message, const QString &file = QString(),
-           int line = -1);
+extern void QLog_(const QString &module, QLogger::LogLevel level, const QString &message, const QString &function,
+                  const QString &file = QString(), int line = -1);
+
+}
 
 #ifndef QLog_Trace
 /**
@@ -165,7 +239,7 @@ void QLog_(const QString &module, QLogger::LogLevel level, const QString &messag
  */
 #   define QLog_Trace(module, message)                                                                                 \
       QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Trace, message, __FILE__,      \
-                                                             __LINE__)
+                                                             __LINE__, __FUNCTION__)
 #endif
 
 #ifndef QLog_Debug
@@ -175,8 +249,8 @@ void QLog_(const QString &module, QLogger::LogLevel level, const QString &messag
  * @param message The message.
  */
 #   define QLog_Debug(module, message)                                                                                 \
-      QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Debug, message, __FILE__,      \
-                                                             __LINE__)
+      QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Debug, message, __FUNCTION__,  \
+                                                             __FILE__, __LINE__)
 #endif
 
 #ifndef QLog_Info
@@ -186,8 +260,8 @@ void QLog_(const QString &module, QLogger::LogLevel level, const QString &messag
  * @param message The message.
  */
 #   define QLog_Info(module, message)                                                                                  \
-      QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Info, message, __FILE__,       \
-                                                             __LINE__)
+      QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Info, message, __FUNCTION__,   \
+                                                             __FILE__, __LINE__)
 #endif
 
 #ifndef QLog_Warning
@@ -197,8 +271,8 @@ void QLog_(const QString &module, QLogger::LogLevel level, const QString &messag
  * @param message The message.
  */
 #   define QLog_Warning(module, message)                                                                               \
-      QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Warning, message, __FILE__,    \
-                                                             __LINE__)
+      QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Warning, message, __FUNCTION__,\
+                                                             __FILE__, __LINE__)
 #endif
 
 #ifndef QLog_Error
@@ -208,8 +282,8 @@ void QLog_(const QString &module, QLogger::LogLevel level, const QString &messag
  * @param message The message.
  */
 #   define QLog_Error(module, message)                                                                                 \
-      QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Error, message, __FILE__,      \
-                                                             __LINE__)
+      QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Error, message, __FUNCTION__,  \
+                                                             __FILE__, __LINE__)
 #endif
 
 #ifndef QLog_Fatal
@@ -219,6 +293,6 @@ void QLog_(const QString &module, QLogger::LogLevel level, const QString &messag
  * @param message The message.
  */
 #   define QLog_Fatal(module, message)                                                                                 \
-      QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Fatal, message, __FILE__,      \
-                                                             __LINE__)
+      QLogger::QLoggerManager::getInstance()->enqueueMessage(module, QLogger::LogLevel::Fatal, message, __FUNCTION__,  \
+                                                             __FILE__, __LINE__)
 #endif

--- a/QLogger.h
+++ b/QLogger.h
@@ -56,6 +56,7 @@ public:
     * @param fileFolderDestination The complete folder destination.
     * @param mode The logging mode.
     * @param fileSuffixIfFull The filename suffix if the file is full.
+    * @param messageOptions Specifies what elements are displayed in one line of log message.
     * @return Returns true if any error have been done.
     */
    bool addDestination(const QString &fileDest, const QString &module, LogLevel level=LogLevel::Warning,
@@ -74,10 +75,11 @@ public:
     * @param fileFolderDestination The complete folder destination.
     * @param mode The logging mode.
     * @param fileSuffixIfFull The filename suffix if the file is full.
+    * @param messageOptions Specifies what elements are displayed in one line of log message.
     * @return Returns true if any error have been done.
     */
    bool addDestination(const QString &fileDest, const QStringList &modules, LogLevel level=LogLevel::Warning,
-                       const QString &fileFolderDestination=QString(),LogMode mode=LogMode::OnlyFile,
+                       const QString &fileFolderDestination=QString(), LogMode mode=LogMode::OnlyFile,
                        LogFileDisplay fileSuffixIfFull=LogFileDisplay::DateTime,
                        LogMessageDisplays messageOptions=LogMessageDisplay::Default, bool notify=true);
    /**
@@ -205,6 +207,21 @@ private:
     * @brief Destructor
     */
    ~QLoggerManager();
+
+   /**
+    * @brief Initializes and returns a new instance of QLoggerWriter with the given parameters.
+    * @param fileDest The file name and path to print logs.
+    * @param level The maximum level allowed.
+    * @param fileFolderDestination The complete folder destination.
+    * @param mode The logging mode.
+    * @param fileSuffixIfFull The filename suffix if the file is full.
+    * @param messageOptions Specifies what elements are displayed in one line of log message.
+    * @return the newly created QLoggerWriter instance.
+    */
+   QLoggerWriter* initializeWriter(const QString &fileDest, LogLevel level,
+                                   const QString &fileFolderDestination, LogMode mode,
+                                   LogFileDisplay fileSuffixIfFull,
+                                   LogMessageDisplays messageOptions) const;
 
    /**
     * @brief Checks the queue and writes the messages if the writer is the correct one. The queue is emptied

--- a/QLogger.h
+++ b/QLogger.h
@@ -68,7 +68,16 @@ public:
     * @return Returns true if any error have been done.
     */
    bool addDestination(const QString &fileDest, const QStringList &modules, LogLevel level);
-
+   
+   /**
+    * @brief Clears old log files from the current storage folder.
+    *
+    * @param fileFolderDestination The destination folder.
+    * @param days Minimum age of log files to delete. Logs older than
+    *        this value will be removed. If days is -1, deletes any log file.
+    */
+   static void clearFileDestinationFolder(const QString &fileFolderDestination, int days=-1);
+   
    /**
     * @brief enqueueMessage Enqueues a message in the corresponding QLoggerWritter.
     * @param module The module that writes the message.

--- a/QLoggerTest/.gitignore
+++ b/QLoggerTest/.gitignore
@@ -1,0 +1,73 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/QLoggerTest/QLoggerTest.pro
+++ b/QLoggerTest/QLoggerTest.pro
@@ -1,0 +1,22 @@
+QT -= gui
+
+CONFIG += c++11 console
+CONFIG -= app_bundle
+
+# You can make your code fail to compile if it uses deprecated APIs.
+# In order to do so, uncomment the following line.
+#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+SOURCES += \
+        main.cpp
+
+# Default rules for deployment.
+qnx: target.path = /tmp/$${TARGET}/bin
+else: unix:!android: target.path = /opt/$${TARGET}/bin
+!isEmpty(target.path): INSTALLS += target
+
+
+!build_pass:message("QLoggerTest: importing QLogger")
+if( !include($$PWD/../QLogger.pri) ) {
+    error( Could not find the QLogger.pri file. )
+}

--- a/QLoggerTest/main.cpp
+++ b/QLoggerTest/main.cpp
@@ -1,0 +1,66 @@
+/**
+ * @file main.cpp
+ * @class main
+ * @author BMOUFLIN
+ * @date 2020-10-09
+ *
+ * @brief The main function
+ *
+ * @module QLoggerTest
+ * @note
+ *
+ * Copyright (c) 2020 NEXO. All rights reserved.
+ * https://nexo-sa.com
+ */
+#include <QCoreApplication>
+
+#include "QLogger.h"
+
+#include <QDebug>
+#include <QTimer>
+#include <QDir>
+
+using namespace QLogger;
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication a(argc, argv);
+
+    qInfo() << "--- QLoggerTest ---";
+    qInfo() << "# Welcome";
+
+    static const QString l_file1("test1.log");
+    static const QString l_file2("test2.log");
+
+    static const QString l_module1("QLoggerTest");
+    static const QString l_module2("TestiiTest");
+
+    QLoggerManager *l_manager = QLoggerManager::getInstance();
+
+    // Create destination with a given file name
+    l_manager->addDestination(l_file1, l_module1, LogLevel::Debug);
+
+    QLog_Debug(l_module1, QStringLiteral("This is a debug log message 0."));
+    QLog_Debug(l_module1, QStringLiteral("This is a debug log message 1.."));
+    QLog_Debug(l_module1, QStringLiteral("This is a debug log message 2..."));
+    QLog_Debug(l_module1, QStringLiteral("This is a debug log message 3...."));
+
+    // Try to create another module of the same name but with a different file name and level - ignoring
+    l_manager->addDestination(l_file2, l_module1, LogLevel::Debug);
+    // The log message is written into the file1
+    QLog_Debug(l_module1, QStringLiteral("This is a debug log message 0."));
+
+    // The module doesn't exist yet - messges are enqueued
+    QLog_Debug(l_module2, QStringLiteral("This is a TestiiTest."));
+    // Create the corresponding module
+    l_manager->addDestination(l_file2, l_module2, LogLevel::Debug);
+    QLog_Debug(l_module2, QStringLiteral("This is a TestiiTest two.."));
+
+
+    QTimer::singleShot(2500, &a, []() {
+        qInfo() << "# Done.";
+        exit(0);
+    } );
+
+    return a.exec();
+}

--- a/QLoggerTest/main.cpp
+++ b/QLoggerTest/main.cpp
@@ -1,8 +1,8 @@
 /**
  * @file main.cpp
  * @class main
- * @author BMOUFLIN
- * @date 2020-10-09
+ * @author Benoît MOUFLIN
+ * @date 2020-11-02
  *
  * @brief The main function
  *
@@ -37,6 +37,8 @@ int main(int argc, char *argv[])
 
     QLoggerManager *l_manager = QLoggerManager::getInstance();
 
+    // --- Default features ---
+
     // Create destination with a given file name
     l_manager->addDestination(l_file1, l_module1, LogLevel::Debug);
 
@@ -57,6 +59,28 @@ int main(int argc, char *argv[])
     QLog_Debug(l_module2, QStringLiteral("This is a TestiiTest two.."));
 
 
+    // --- New features ---
+    static const QString l_file3("test3.log");
+
+    static const QString l_module3("QLoggerTest2");
+    static const QString l_module4("TestiiTest2");
+
+    // Create module at the default destination folder and full mode (console and file)
+    l_manager->addDestination(l_file3, l_module3, LogLevel::Debug, QString(), LogMode::Full);
+
+    QLog_Debug(l_module3, QStringLiteral("This is a debug log message 0."));
+    QLog_Debug(l_module3, QStringLiteral("This is a debug log message 1.."));
+    QLog_Debug(l_module3, QStringLiteral("This is a debug log message 2..."));
+    QLog_Debug(l_module3, QStringLiteral("This is a debug log message 3...."));
+
+    // The module doesn't exist yet - messges are enqueued
+    QLog_Debug(l_module4, QStringLiteral("This is a TestiiTest."));
+    // Create the corresponding module with auto-generated filename, default destination folder with a custom log message display
+    l_manager->addDestination(QString(), l_module4, LogLevel::Debug, QString(), LogMode::Full
+                              , LogFileDisplay::Number, LogMessageDisplay::DateTime|LogMessageDisplay::Message);
+    QLog_Debug(l_module4, QStringLiteral("This is a TestiiTest two.."));
+
+
     QTimer::singleShot(2500, &a, []() {
         qInfo() << "# Done.";
         exit(0);
@@ -64,3 +88,4 @@ int main(int argc, char *argv[])
 
     return a.exec();
 }
+

--- a/QLoggerWriter.cpp
+++ b/QLoggerWriter.cpp
@@ -106,14 +106,14 @@ QString QLoggerWriter::renameFileIfFull()
    return QString();
 }
 
-QString QLoggerWriter::generateDuplicateFilename(const QString& fileDestination, const QString& fileExtension, int p_number)
+QString QLoggerWriter::generateDuplicateFilename(const QString& fileDestination, const QString& fileExtension, int fileSuffixNumber)
 {
     QString path(fileDestination);
-    if (p_number > 1) {
+    if (fileSuffixNumber > 1) {
         // Set the new display name
         path = QString("%1(%2).%3")
                         .arg(fileDestination,
-                             QString::number(p_number),
+                             QString::number(fileSuffixNumber),
                              fileExtension);
     } else {
         path.append(QString(".%1").arg(fileExtension));
@@ -121,7 +121,7 @@ QString QLoggerWriter::generateDuplicateFilename(const QString& fileDestination,
 
     if (QFileInfo::exists(path)) {
         // A name already exists, increment the number and check again
-        return generateDuplicateFilename(fileDestination, fileExtension, p_number+1);
+        return generateDuplicateFilename(fileDestination, fileExtension, fileSuffixNumber+1);
     }
 
     // No file exists at the given location, so no need to continue
@@ -158,6 +158,8 @@ void QLoggerWriter::write(const QPair<QString, QString> &message)
 void QLoggerWriter::enqueue(const QDateTime &date, const QString &threadId, const QString &module, LogLevel level,
                             const QString &function, const QString &fileName, int line, const QString &message)
 {
+   QMutexLocker locker(&mutex);
+
    if (mMode == LogMode::Disabled)
       return;
 
@@ -201,7 +203,6 @@ void QLoggerWriter::enqueue(const QDateTime &date, const QString &threadId, cons
        text.append(QString::fromLatin1("\n"));
    }
 
-   QMutexLocker locker(&mutex);
    messages.append({ threadId, text });
 
    mQueueNotEmpty.wakeOne();

--- a/QLoggerWriter.cpp
+++ b/QLoggerWriter.cpp
@@ -3,9 +3,16 @@
 #include <QDateTime>
 #include <QFile>
 #include <QTextStream>
+#include <QDir>
+#include <QDebug>
 
 namespace
 {
+/**
+ * @brief Converts the given level in a QString.
+ * @param level The log level in LogLevel format.
+ * @return The string with the name of the log level.
+ */
 QString levelToText(const QLogger::LogLevel &level)
 {
    switch (level)
@@ -31,10 +38,43 @@ QString levelToText(const QLogger::LogLevel &level)
 namespace QLogger
 {
 
-QLoggerWriter::QLoggerWriter(const QString &fileDestination, LogLevel level)
+QLoggerWriter::QLoggerWriter(const QString &fileDestination, LogLevel level, const QString &fileFolderDestination,
+                             LogMode mode, LogFileDisplay fileSuffixIfFull, LogMessageDisplays messageOptions) :
+    mFileSuffixIfFull(fileSuffixIfFull),
+    mMode(mode),
+    mLevel(level),
+    mMessageOptions(messageOptions)
 {
-   mFileDestination = "logs/" + fileDestination;
-   mLevel = level;
+   mFileDestinationFolder = (fileFolderDestination.isEmpty() ? QDir::currentPath() : fileFolderDestination) + "/logs/";
+   mFileDestination = mFileDestinationFolder + fileDestination;
+
+   QDir dir(mFileDestinationFolder);
+   if (fileDestination.isEmpty()) {
+       // Generate a filname according to the date
+       mFileDestination = dir.filePath(QString::fromLatin1("%1.log").arg(QDateTime::currentDateTime().date().toString(QString::fromLatin1("yyyy-MM-dd"))));
+   } else if (!fileDestination.contains(QLatin1Char('.'))) {
+       // Add default file extension
+       mFileDestination.append(QString::fromLatin1(".log"));
+   }
+
+   if (mMode == LogMode::Full || mMode == LogMode::OnlyFile) {
+       dir.mkpath(QStringLiteral("."));
+   }
+}
+
+
+void QLoggerWriter::setLogMode(LogMode mode)
+{
+   mMode = mode;
+
+   if (mMode == LogMode::Full || mMode == LogMode::OnlyFile) {
+       QDir dir(mFileDestinationFolder);
+       dir.mkpath(QStringLiteral("."));
+   }
+
+   if (mode != LogMode::Disabled && !this->isRunning()) {
+       this->start();
+   }
 }
 
 QString QLoggerWriter::renameFileIfFull()
@@ -42,11 +82,21 @@ QString QLoggerWriter::renameFileIfFull()
    QFile file(mFileDestination);
 
    // Rename file if it's full
-   if (file.size() >= MaxFileSize)
+   if (file.size() >= mMaxFileSize)
    {
-      const auto newName = QString("%1_%2.log")
-                               .arg(mFileDestination.left(mFileDestination.lastIndexOf('.')),
-                                    QDateTime::currentDateTime().toString("dd_MM_yy__hh_mm_ss"));
+      QString newName;
+
+      const auto fileDestination = mFileDestination.left(mFileDestination.lastIndexOf('.'));
+      const auto fileExtension = mFileDestination.mid(mFileDestination.lastIndexOf('.')+1);
+
+      if (mFileSuffixIfFull == LogFileDisplay::DateTime) {
+          newName = QString("%1_%2.%3")
+                          .arg(fileDestination,
+                               QDateTime::currentDateTime().toString("dd_MM_yy__hh_mm_ss"),
+                               fileExtension);
+      } else {
+          newName = generateDuplicateFilename(fileDestination, fileExtension);
+      }
 
       const auto renamed = file.rename(mFileDestination, newName);
 
@@ -56,8 +106,38 @@ QString QLoggerWriter::renameFileIfFull()
    return QString();
 }
 
+QString QLoggerWriter::generateDuplicateFilename(const QString& fileDestination, const QString& fileExtension, int p_number)
+{
+    QString path(fileDestination);
+    if (p_number > 1) {
+        // Set the new display name
+        path = QString("%1(%2).%3")
+                        .arg(fileDestination,
+                             QString::number(p_number),
+                             fileExtension);
+    } else {
+        path.append(QString(".%1").arg(fileExtension));
+    }
+
+    if (QFileInfo::exists(path)) {
+        // A name already exists, increment the number and check again
+        return generateDuplicateFilename(fileDestination, fileExtension, p_number+1);
+    }
+
+    // No file exists at the given location, so no need to continue
+    return path;
+}
+
 void QLoggerWriter::write(const QPair<QString, QString> &message)
 {
+   // Write data to console
+   if (mMode == LogMode::OnlyConsole || mMode == LogMode::Full)
+      qInfo() << message.second;
+
+   if (mMode == LogMode::OnlyConsole)
+      return;
+
+   // Write data to file
    QFile file(mFileDestination);
 
    const auto prevFilename = renameFileIfFull();
@@ -76,16 +156,50 @@ void QLoggerWriter::write(const QPair<QString, QString> &message)
 }
 
 void QLoggerWriter::enqueue(const QDateTime &date, const QString &threadId, const QString &module, LogLevel level,
-                            const QString &fileName, int line, const QString &message)
+                            const QString &function, const QString &fileName, int line, const QString &message)
 {
+   if (mMode == LogMode::Disabled)
+      return;
+
    QString fileLine;
+   if (mMessageOptions.testFlag(LogMessageDisplay::FileLine) && !fileName.isEmpty() && line > 0 && mLevel <= LogLevel::Debug)
+        fileLine = QString(" {%1:%2}").arg(fileName, QString::number(line));
 
-   if (!fileName.isEmpty() && line > 0 && mLevel <= LogLevel::Debug)
-      fileLine = QString(" {%1:%2}").arg(fileName, QString::number(line));
-
-   const auto text
-       = QString("[%1] [%2] [%3] [%4]%5 %6 \n")
-             .arg(levelToText(level), module, date.toString("dd-MM-yyyy hh:mm:ss.zzz"), threadId, fileLine, message);
+   QString text;
+   if (mMessageOptions.testFlag(LogMessageDisplay::Default)) {
+       text = QString("[%1] [%2] [%3] [%4]%5 %6 \n")
+                 .arg(levelToText(level), module, date.toString("dd-MM-yyyy hh:mm:ss.zzz"), threadId, fileLine, message);
+   } else {
+       if (mMessageOptions.testFlag(LogMessageDisplay::LogLevel)) {
+            text.append(QString("[%1]").arg(levelToText(level)));
+       }
+       if (mMessageOptions.testFlag(LogMessageDisplay::ModuleName)) {
+           text.append(QString("[%1]").arg(module));
+       }
+       if (mMessageOptions.testFlag(LogMessageDisplay::DateTime)) {
+           text.append(QString("[%1]").arg(date.toString("yyyy-MM-dd hh:mm:ss.zzz")));
+       }
+       if (mMessageOptions.testFlag(LogMessageDisplay::ThreadId)) {
+           text.append(QString("[%1]").arg(threadId));
+       }
+       if (mMessageOptions.testFlag(LogMessageDisplay::Function) && !function.isEmpty()) {
+           text.append(QString("[%1]").arg(function));
+       }
+       if (mMessageOptions.testFlag(LogMessageDisplay::FileLine) && !fileLine.isEmpty()) {
+           if (fileLine.startsWith(QChar::Space)) {
+               fileLine = fileLine.right(1);
+           }
+           text.append(QString("%1").arg(fileLine));
+       }
+       if (mMessageOptions.testFlag(LogMessageDisplay::Message)) {
+           if (text.isEmpty() || text.endsWith(QChar::Space)) {
+               text.append(QString("%1").arg(message));
+           } else {
+               text.append(QString(" %1").arg(message));
+           }
+       }
+       text.append(QString::fromLatin1("\n"));
+   }
 
    QMutexLocker locker(&mutex);
    messages.append({ threadId, text });

--- a/QLoggerWriter.h
+++ b/QLoggerWriter.h
@@ -41,8 +41,33 @@ public:
     * configures the level of this file to filter the logs depending on the level.
     * @param fileDestination The complete path.
     * @param level The maximum level that is allowed.
+    * @param fileFolderDestination The complete folder destination.
+    * @param mode The logging mode.
+    * @param fileSuffixIfFull The filename suffix if the file is full.
     */
-   explicit QLoggerWriter(const QString &fileDestination, LogLevel level);
+   explicit QLoggerWriter(const QString &fileDestination, LogLevel level=LogLevel::Warning, const QString &fileFolderDestination=QString(),
+                          LogMode mode=LogMode::OnlyFile, LogFileDisplay fileSuffixIfFull=LogFileDisplay::DateTime, LogMessageDisplays messageOptions=LogMessageDisplay::Default);
+
+   /**
+    * @brief Gets path and folder of the file that will store the logs.
+    */
+   QString getFileDestinationFolder() const { return mFileDestinationFolder; }
+   /**
+    * @brief Path and name of the file that will store the logs.
+    */
+   QString getFileDestination() const { return mFileDestination; }
+
+   /**
+    * @brief Gets the current logging mode.
+    * @return The level.
+    */
+   LogMode getMode() const { return mMode; }
+
+   /**
+    * @brief setLogMode Sets the log mode for this destination.
+    * @param mode
+    */
+   void setLogMode(LogMode mode);
 
    /**
     * @brief Gets the current level threshold.
@@ -51,10 +76,34 @@ public:
    LogLevel getLevel() const { return mLevel; }
 
    /**
-    * @brief setLogLevel Sets the log level for this destination
+    * @brief setLogLevel Sets the log level for this destination.
     * @param level The new level threshold.
     */
    void setLogLevel(LogLevel level) { mLevel = level; }
+
+   /**
+    * @brief Gets the current max size for the log file.
+    * @return The maximum size
+    */
+   int getMaxFileSize() const { return mMaxFileSize; }
+
+   /**
+    * @brief setMaxFileSize Sets the max file size for this destination.
+    * @param maxSize The new file size
+    */
+   void setMaxFileSize(int maxSize) { mMaxFileSize = maxSize; }
+
+   /**
+    * @brief getMessageOptions Gets the current message options.
+    * @return The current options
+    */
+   LogMessageDisplays getMessageOptions() const { return mMessageOptions; }
+
+   /**
+    * @brief setMessageOptions Specifies what elements are displayed in one line of log message.
+    * @param messageOptions The options
+    */
+   void setMessageOptions(LogMessageDisplays messageOptions) { mMessageOptions = messageOptions; }
 
    /**
     * @brief enqueue Enqueues a message to be written in the destiantion.
@@ -62,11 +111,12 @@ public:
     * @param threadId The thread where the message comes from.
     * @param module The module that writes the message.
     * @param level The log level of the message.
+    * @param function The function that prints the log.
     * @param fileName The file name that prints the log.
     * @param line The line of the file name that prints the log.
     * @param message The message to log.
     */
-   void enqueue(const QDateTime &date, const QString &threadId, const QString &module, LogLevel level,
+   void enqueue(const QDateTime &date, const QString &threadId, const QString &module, LogLevel level, const QString &function,
                 const QString &fileName, int line, const QString &message);
 
    /**
@@ -89,19 +139,33 @@ private:
    bool mQuit = false;
    bool mIsStop = false;
    QWaitCondition mQueueNotEmpty;
+   QString mFileDestinationFolder;
    QString mFileDestination;
+   LogFileDisplay mFileSuffixIfFull;
+   LogMode mMode;
    LogLevel mLevel;
+   int mMaxFileSize = 1024 * 1024;  //! @note 1Mio
+   LogMessageDisplays mMessageOptions;
    QVector<QPair<QString, QString>> messages;
    QMutex mutex;
-   static const int MaxFileSize = 1024 * 1024;
 
    /**
     * @brief renameFileIfFull Truncates the log file in two. Keeps the filename for the new one and renames the old one
-    * with the timestamp.
+    * with the timestamp or with a file number.
     *
     * @return Returns the file name for the old logs.
     */
    QString renameFileIfFull();
+
+   /**
+    * @brief generateDuplicateFilename
+    *
+    * @param fileDestination The file path and name without the extension.
+    * @param fileExtension The file extension
+    * @param p_number The file suffix number.
+    * @return The complete path of the duplicated file name.
+    */
+   static QString generateDuplicateFilename(const QString& fileDestination, const QString& fileExtension, int p_number=1);
 
    /**
     * @brief Writes a message in a file. If the file is full, it truncates it and prints a first line with the

--- a/QLoggerWriter.h
+++ b/QLoggerWriter.h
@@ -162,10 +162,10 @@ private:
     *
     * @param fileDestination The file path and name without the extension.
     * @param fileExtension The file extension
-    * @param p_number The file suffix number.
+    * @param fileSuffixNumber The file suffix number.
     * @return The complete path of the duplicated file name.
     */
-   static QString generateDuplicateFilename(const QString& fileDestination, const QString& fileExtension, int p_number=1);
+   static QString generateDuplicateFilename(const QString& fileDestination, const QString& fileExtension, int fileSuffixNumber=1);
 
    /**
     * @brief Writes a message in a file. If the file is full, it truncates it and prints a first line with the


### PR DESCRIPTION
### QLoggerWriter

- Added logging mode (write only into the console, only into the file, both or disabled)
- Possibility to set the maximum file size
- Default destination file name and extension
- Added option for the previous log file suffix (display date time or file number)
- Added options for log message display
- Native separators conversion for destination paths

### QLoggerManager

- Default folder path, fileSuffixIfFull, mode, level and max file size for all destinations if not set. Useful for multiple QLoggerWritter.
- Can clear file festination folder
- AddDestination: added notify argument if we want to write a notification into the created log file