### PR TITLE
Various adaptations

### DIFF
--- a/QLogger.h
+++ b/QLogger.h
@@ -22,9 +22,9 @@
  ** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************************************/
 
-#include <QLoggerLevel.h>
+#include "QLoggerLevel.h"
 
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QMap>
 #include <QVariant>
 
@@ -43,10 +43,13 @@ public:
     * @brief Gets an instance to the QLoggerManager.
     * @return A pointer to the instance.
     */
-   static QLoggerManager *getInstance();
+   static QLoggerManager &getInstance();
+
+   bool hasModules() const;
+   bool hasModule(const QString &module) const;
 
    /**
-    * @brief This method creates a QLoogerWriter that stores the name of the file and the log
+    * @brief This method creates a QLoggerWriter that stores the name of the file and the log
     * level assigned to it. Here is added to the map the different modules assigned to each
     * log file. The method returns <em>false</em> if a module is configured to be stored in
     * more than one file.
@@ -56,16 +59,18 @@ public:
     * @param level The maximum level allowed.
     * @param fileFolderDestination The complete folder destination.
     * @param mode The logging mode.
-    * @param fileSuffixIfFull The filename suffix if the file is full.
+    * @param fileTag The file tag.
+    * @param fileHandling file handling modes
     * @param messageOptions Specifies what elements are displayed in one line of log message.
     * @return Returns true if any error have been done.
     */
    bool addDestination(const QString &fileDest, const QString &module, LogLevel level = LogLevel::Warning,
-                       const QString &fileFolderDestination = QString(), LogMode mode = LogMode::OnlyFile,
-                       LogFileDisplay fileSuffixIfFull = LogFileDisplay::DateTime,
+                       const QString &fileFolderDestination = QString(), LogMode mode = LogMode::Default,
+                       LogFileTag fileTag = LogFileTag::Default,
+                       LogFileHandling fileHandling = LogFileHandling::Default, 
                        LogMessageDisplays messageOptions = LogMessageDisplay::Default, bool notify = true);
    /**
-    * @brief This method creates a QLoogerWriter that stores the name of the file and the log
+    * @brief This method creates a QLoggerWriter that stores the name of the file and the log
     * level assigned to it. Here is added to the map the different modules assigned to each
     * log file. The method returns <em>false</em> if a module is configured to be stored in
     * more than one file.
@@ -75,13 +80,15 @@ public:
     * @param level The maximum level allowed.
     * @param fileFolderDestination The complete folder destination.
     * @param mode The logging mode.
-    * @param fileSuffixIfFull The filename suffix if the file is full.
+    * @param fileTag The file tag.
+    * @param fileHandling file handling modes
     * @param messageOptions Specifies what elements are displayed in one line of log message.
     * @return Returns true if any error have been done.
     */
    bool addDestination(const QString &fileDest, const QStringList &modules, LogLevel level = LogLevel::Warning,
-                       const QString &fileFolderDestination = QString(), LogMode mode = LogMode::OnlyFile,
-                       LogFileDisplay fileSuffixIfFull = LogFileDisplay::DateTime,
+                       const QString &fileFolderDestination = QString(), LogMode mode = LogMode::Default,
+                       LogFileTag fileTag = LogFileTag::Default,
+                       LogFileHandling fileHandling = LogFileHandling::Default,  
                        LogMessageDisplays messageOptions = LogMessageDisplay::Default, bool notify = true);
    /**
     * @brief Clears old log files from the current storage folder.
@@ -141,7 +148,8 @@ public:
     */
    void setDefaultFileDestinationFolder(const QString &fileDestinationFolder);
    void setDefaultFileDestination(const QString &fileDestination) { mDefaultFileDestination = fileDestination; }
-   void setDefaultFileSuffixIfFull(LogFileDisplay fileSuffixIfFull) { mDefaultFileSuffixIfFull = fileSuffixIfFull; }
+   void setDefaultFileTag(LogFileTag fileTag) { mDefaultFileTag = fileTag; }
+   void setDefaultFileHandling(LogFileHandling fileHandling) { mDefaultFileHandling = fileHandling; }
 
    void setDefaultLevel(LogLevel level) { mDefaultLevel = level; }
    void setDefaultMode(LogMode mode) { mDefaultMode = mode; }
@@ -195,7 +203,8 @@ private:
     */
    QString mDefaultFileDestinationFolder;
    QString mDefaultFileDestination;
-   LogFileDisplay mDefaultFileSuffixIfFull = LogFileDisplay::DateTime;
+   LogFileTag mDefaultFileTag = LogFileTag::DateTime;
+   LogFileHandling mDefaultFileHandling = LogFileHandling::Split;
 
    LogMode mDefaultMode = LogMode::OnlyFile;
    LogLevel mDefaultLevel = LogLevel::Warning;
@@ -206,7 +215,7 @@ private:
    /**
     * @brief Mutex to make the method thread-safe.
     */
-   QMutex mMutex { QMutex::Recursive };
+   QRecursiveMutex mMutex;
 
    /**
     * @brief Default builder of the class. It starts the thread.
@@ -224,12 +233,14 @@ private:
     * @param level The maximum level allowed.
     * @param fileFolderDestination The complete folder destination.
     * @param mode The logging mode.
-    * @param fileSuffixIfFull The filename suffix if the file is full.
+    * @param fileTag The file tag.
+    * @param fileHandling File handling modes
     * @param messageOptions Specifies what elements are displayed in one line of log message.
     * @return the newly created QLoggerWriter instance.
     */
    QLoggerWriter *createWriter(const QString &fileDest, LogLevel level, const QString &fileFolderDestination,
-                               LogMode mode, LogFileDisplay fileSuffixIfFull, LogMessageDisplays messageOptions) const;
+                               LogMode mode, LogFileTag fileTag, LogFileHandling fileHandling,
+                               LogMessageDisplays messageOptions) const;
 
    void startWriter(const QString &module, QLoggerWriter *log, LogMode mode, bool notify);
 

--- a/QLoggerLevel.h
+++ b/QLoggerLevel.h
@@ -49,16 +49,29 @@ enum class LogMode
     Disabled = 0,
     OnlyConsole,
     OnlyFile,
-    Full
+    Full,
+    Default
 };
 
 /**
- * @brief The LogFileDisplay enum class defines which elements are written in the log file name.
+ * @brief The LogFileTag enum class defines the additional tag for the log file name.
  */
-enum class LogFileDisplay
+enum class LogFileTag
 {
     DateTime,
-    Number
+    Number,
+    Default
+};
+
+/**
+ * @brief The LogFileHandling enum class defines how the logfile is handled
+ */
+enum class LogFileHandling
+{
+    Single,        // single file, with original name
+    SingleTagged,  // single file, with original name plus a tag according to LogFileTag
+    Split,         // keep original name but split on predefined file size with tag according to LogFileTag 
+    Default
 };
 
 /**

--- a/QLoggerWriter.h
+++ b/QLoggerWriter.h
@@ -22,7 +22,7 @@
  ** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  ***************************************************************************************/
 
-#include <QLoggerLevel.h>
+#include "QLoggerLevel.h"
 
 #include <QThread>
 #include <QWaitCondition>
@@ -44,21 +44,25 @@ public:
     * @param level The maximum level that is allowed.
     * @param fileFolderDestination The complete folder destination.
     * @param mode The logging mode.
-    * @param fileSuffixIfFull The filename suffix if the file is full.
+    * @param fileTag The file tag.
+    * @param fileHandling file handling modes
+    * @param messageOptions Specifies what elements are displayed in one line of log message.
     */
    explicit QLoggerWriter(const QString &fileDestination, LogLevel level = LogLevel::Warning,
-                          const QString &fileFolderDestination = QString(), LogMode mode = LogMode::OnlyFile,
-                          LogFileDisplay fileSuffixIfFull = LogFileDisplay::DateTime,
+                          const QString &fileFolderDestination = QString(), LogMode mode = LogMode::Default,
+                          LogFileTag fileTag = LogFileTag::Default,
+                          LogFileHandling fileHandling = LogFileHandling::Default,
                           LogMessageDisplays messageOptions = LogMessageDisplay::Default);
 
    /**
     * @brief Gets path and folder of the file that will store the logs.
     */
    QString getFileDestinationFolder() const { return mFileDestinationFolder; }
+
    /**
     * @brief Path and name of the file that will store the logs.
     */
-   QString getFileDestination() const { return mFileDestination; }
+   QString getFileDestination() const;
 
    /**
     * @brief Gets the current logging mode.
@@ -149,14 +153,26 @@ private:
    bool mIsStop = false;
    QWaitCondition mQueueNotEmpty;
    QString mFileDestinationFolder;
-   QString mFileDestination;
-   LogFileDisplay mFileSuffixIfFull;
+   QString mBareFileDestination;
+   QString mDateTag; 
+   LogFileTag mFileTag;
+   LogFileHandling mFileHandling;
    LogMode mMode;
    LogLevel mLevel;
    int mMaxFileSize = 1024 * 1024; //! @note 1Mio
    LogMessageDisplays mMessageOptions;
    QVector<QString> mMessages;
    QMutex mutex;
+
+   /**
+    * @brief generates a date tag
+    */
+   QString mkDateTag() const;
+
+   /**
+    * @brief Path and name of the file extended with the tag.
+    */
+   QString getTaggedFileDestination(const QString& dateTag) const;
 
    /**
     * @brief renameFileIfFull Truncates the log file in two. Keeps the filename for the new one and renames the old one


### PR DESCRIPTION
Hi Frances,
I have used your library as a submodule for kdenlive to implement a code tracer. I was having some problems making it thread safe. At first I  tried something myself, because it appeared quite simple at first adding a QWriteLocker. However it is not thàt simple apparently because that did crash occasionally while logging to a file. So then I moved in your library and that works ok, thanks!

I made some changes to it that are described here below. You are welcome to tweak or modify this further any way you like if you want this. Thanks again,
Ondrej 

- made QLoggerManager::getInstance() return a reference instead of a pointer

- added

     bool QLoggerManager::hasModules() const
     bool QLoggerManager::hasModule(const QString& module) const

     to check for, and add a destination on the fly,
     if you do not have (or want to have) a seperate configuration section

- changed QMutex mMutex { QMutex::Recursive } -> QRecursiveMutex mMutex

- added QDebug.noquote().nospace() to console formatting

- moved the addition of the newline character to writing to file only
  because qInfo() adds already its own.

- renamed QLogger::LogFileDisplay -> QLogger::LogFileTag

- added QLogger::LogFileHandling to specify a file handling mode,
```
    enum class LogFileHandling
    {
        Single,        // single file, with original name
        SingleTagged,  // single file, with original name plus a tag according to LogFileTag
        Split,         // the original behaviour : keep original name but split on predefined file size with tag according to LogFileTag
        Default        // select predefined default choice
    }
```

- also added 'Default' enumerators to LogMode and LogFileTag to more correctly detect the default choice